### PR TITLE
Fix DB Error of FederationConfigurationEndpoint

### DIFF
--- a/src/main/java/ext/federation/entity/OIDCFedConfigEntity.java
+++ b/src/main/java/ext/federation/entity/OIDCFedConfigEntity.java
@@ -1,10 +1,13 @@
-package org.keycloak.protocol.oidc.federation.op.model;
+package ext.federation.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
+import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfig;
+import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfigJsonConverter;
 
 @Entity
 @Table(name = "OIDC_FEDERATION_CONFIG")

--- a/src/main/java/org/keycloak/protocol/oidc/federation/op/model/OIDCFedConfigJpaEntityProvider.java
+++ b/src/main/java/org/keycloak/protocol/oidc/federation/op/model/OIDCFedConfigJpaEntityProvider.java
@@ -2,6 +2,8 @@ package org.keycloak.protocol.oidc.federation.op.model;
 
 import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
 
+import ext.federation.entity.OIDCFedConfigEntity;
+
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/org/keycloak/protocol/oidc/federation/op/model/OIDCFedConfigService.java
+++ b/src/main/java/org/keycloak/protocol/oidc/federation/op/model/OIDCFedConfigService.java
@@ -6,6 +6,8 @@ import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 
+import ext.federation.entity.OIDCFedConfigEntity;
+
 public class OIDCFedConfigService {
 
     private final RealmModel realm;

--- a/src/main/java/org/keycloak/protocol/oidc/federation/op/rest/FederationConfigurationEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/oidc/federation/op/rest/FederationConfigurationEndpoint.java
@@ -18,7 +18,6 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfig;
-import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfigEntity;
 import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfigService;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.services.ErrorResponse;
@@ -28,6 +27,8 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
+
+import ext.federation.entity.OIDCFedConfigEntity;
 
 public class FederationConfigurationEndpoint {
 

--- a/src/main/java/org/keycloak/protocol/oidc/federation/op/spi/OIDCFedOPWellKnownProvider.java
+++ b/src/main/java/org/keycloak/protocol/oidc/federation/op/spi/OIDCFedOPWellKnownProvider.java
@@ -40,7 +40,6 @@ import org.keycloak.protocol.oidc.federation.common.beans.Metadata;
 import org.keycloak.protocol.oidc.federation.common.beans.OPMetadata;
 import org.keycloak.protocol.oidc.federation.common.exceptions.InternalServerErrorException;
 import org.keycloak.protocol.oidc.federation.common.helpers.FedUtils;
-import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfigEntity;
 import org.keycloak.protocol.oidc.federation.op.model.OIDCFedConfigService;
 import org.keycloak.protocol.oidc.federation.op.rest.FederationOPService;
 import org.keycloak.protocol.oidc.federation.op.rest.OIDCFederationResourceProvider;
@@ -51,6 +50,7 @@ import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.urls.UrlType;
 import org.keycloak.util.JsonSerialization;
 
+import ext.federation.entity.OIDCFedConfigEntity;
 
 public class OIDCFedOPWellKnownProvider extends OIDCWellKnownProvider {
 


### PR DESCRIPTION
I guess that for custom entity with default persistence unit, a package name of the entity class should be "org.keycloak.testsuite*" or something other than "org.keycloak*" from configureDefaultPersistenceUnitEntities method in KeycloakProcessor.java below:

```
private void configureDefaultPersistenceUnitEntities(ParsedPersistenceXmlDescriptor descriptor, CombinedIndexBuildItem indexBuildItem,
            List<String> userManagedEntities) {
        IndexView index = indexBuildItem.getIndex();
        Collection<AnnotationInstance> annotations = index.getAnnotations(DotName.createSimple(Entity.class.getName()));

        for (AnnotationInstance annotation : annotations) {
            AnnotationTarget target = annotation.target();
            String targetName = target.asClass().name().toString();

            if (!userManagedEntities.contains(targetName)
                    && (!targetName.startsWith("org.keycloak") || targetName.startsWith("org.keycloak.testsuite"))) {
                descriptor.addClasses(targetName);
            }
        }
    }
```

If it is correct, 
"org.keycloak.protocol.oidc.federation.op.rest", the package name of OIDCFedConfigEntity, has to be modified.

And also, I guess that this modification should resolve an issue below: 
https://github.com/keycloak/keycloak/discussions/31027#discussioncomment-10868142
